### PR TITLE
feat: Implement middleware-based auth protection

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -33,19 +33,6 @@ export default function Dashboard() {
   const { user, loading } = useAuth()
   const router = useRouter()
 
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
-      </div>
-    )
-  }
-
-  if (!user) {
-    router.push("/login")
-    return null
-  }
-
   const handleLogout = async () => {
     try {
       await import("@/lib/firebase").then(({ logoutUser }) => logoutUser())
@@ -54,6 +41,14 @@ export default function Dashboard() {
     } catch (error) {
       toast.error("Failed to logout")
     }
+  }
+
+  if (loading || !user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
+      </div>
+    )
   }
 
   // Mock data for demonstration

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -21,39 +21,46 @@ export const googleProvider = new GoogleAuthProvider()
 // Authentication functions
 export const signInWithGoogle = async () => {
   try {
-    const result = await signInWithPopup(auth, googleProvider)
-    return result.user
+    const result = await signInWithPopup(auth, googleProvider);
+    const token = await result.user.getIdToken();
+    document.cookie = `firebaseIdToken=${token}; path=/`;
+    return result.user;
   } catch (error) {
-    console.error("Error signing in with Google:", error)
-    throw error
+    console.error("Error signing in with Google:", error);
+    throw error;
   }
-}
+};
 
 export const signInWithEmail = async (email: string, password: string) => {
   try {
-    const result = await signInWithEmailAndPassword(auth, email, password)
-    return result.user
+    const result = await signInWithEmailAndPassword(auth, email, password);
+    const token = await result.user.getIdToken();
+    document.cookie = `firebaseIdToken=${token}; path=/`;
+    return result.user;
   } catch (error) {
-    console.error("Error signing in with email:", error)
-    throw error
+    console.error("Error signing in with email:", error);
+    throw error;
   }
-}
+};
 
 export const signUpWithEmail = async (email: string, password: string) => {
   try {
-    const result = await createUserWithEmailAndPassword(auth, email, password)
-    return result.user
+    const result = await createUserWithEmailAndPassword(auth, email, password);
+    const token = await result.user.getIdToken();
+    document.cookie = `firebaseIdToken=${token}; path=/`;
+    return result.user;
   } catch (error) {
-    console.error("Error signing up with email:", error)
-    throw error
+    console.error("Error signing up with email:", error);
+    throw error;
   }
-}
+};
 
 export const logoutUser = async () => {
   try {
-    await signOut(auth)
+    await signOut(auth);
+    document.cookie = "firebaseIdToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
   } catch (error) {
-    console.error("Error signing out:", error)
-    throw error
+    console.error("Error signing out:", error);
+    throw error;
   }
-}
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,27 @@
+// src/middleware.ts
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('firebaseIdToken');
+  const { pathname } = request.nextUrl;
+
+  // If the user is trying to access the dashboard without a token, redirect to login
+  if (!token && pathname.startsWith('/dashboard')) {
+    const loginUrl = new URL('/login', request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // If the user is logged in and tries to access the login page, redirect to dashboard
+  if (token && pathname === '/login') {
+    const dashboardUrl = new URL('/dashboard', request.url);
+    return NextResponse.redirect(dashboardUrl);
+  }
+
+  return NextResponse.next();
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: '/dashboard/:path*',
+}


### PR DESCRIPTION
Replaced the client-side redirect logic with a more robust server-side authentication check using Next.js middleware.

The previous implementation had a race condition where the dashboard page would redirect to the login page before the client-side authentication state was fully resolved.

This commit introduces the following changes:
- A new middleware at `src/middleware.ts` protects the `/dashboard` route.
- The Firebase authentication functions in `src/lib/firebase.ts` now set a `firebaseIdToken` cookie on login and clear it on logout.
- The client-side redirect logic in `src/app/dashboard/page.tsx` has been removed in favor of the middleware.