### PR TITLE
Fix: Remove Secure flag from auth cookie for HTTP environments

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -31,7 +31,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (result) {
           toast.success("Successfully logged in with Google!")
           const token = await result.user.getIdToken();
-          document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax; Secure`;
+          document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax`;
           // The onAuthStateChanged listener will handle setting the user
         }
       })

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -32,7 +32,7 @@ export const signInWithEmail = async (email: string, password: string) => {
   try {
     const result = await signInWithEmailAndPassword(auth, email, password);
     const token = await result.user.getIdToken();
-    document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax; Secure`;
+    document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax`;
     return result.user;
   } catch (error) {
     console.error("Error signing in with email:", error);
@@ -44,7 +44,7 @@ export const signUpWithEmail = async (email: string, password: string) => {
   try {
     const result = await createUserWithEmailAndPassword(auth, email, password);
     const token = await result.user.getIdToken();
-    document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax; Secure`;
+    document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax`;
     return result.user;
   } catch (error) {
     console.error("Error signing up with email:", error);
@@ -55,7 +55,7 @@ export const signUpWithEmail = async (email: string, password: string) => {
 export const logoutUser = async () => {
   try {
     await signOut(auth);
-    document.cookie = "firebaseIdToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax; Secure";
+    document.cookie = "firebaseIdToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax";
   } catch (error) {
     console.error("Error signing out:", error);
     throw error;


### PR DESCRIPTION
This commit attempts to resolve a persistent issue where users could log in but not access the dashboard. The likely cause is the `Secure` flag on the authentication cookie preventing it from being sent over non-HTTPS connections.

This change removes the `Secure` flag from the cookie-setting logic in `src/lib/firebase.ts` and `src/contexts/auth-context.tsx`. This should allow the authentication flow to work correctly in development or testing environments that use HTTP.

This change is built upon the previous overhaul of the authentication system, which included:
- Implementing server-side route protection with middleware.
- Switching to a redirect-based flow for Google Sign-In.