### PR TITLE
Revert: Add Secure flag back to auth cookie

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -31,7 +31,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (result) {
           toast.success("Successfully logged in with Google!")
           const token = await result.user.getIdToken();
-          document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax`;
+          document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax; Secure`;
           // The onAuthStateChanged listener will handle setting the user
         }
       })

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -32,7 +32,7 @@ export const signInWithEmail = async (email: string, password: string) => {
   try {
     const result = await signInWithEmailAndPassword(auth, email, password);
     const token = await result.user.getIdToken();
-    document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax`;
+    document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax; Secure`;
     return result.user;
   } catch (error) {
     console.error("Error signing in with email:", error);
@@ -44,7 +44,7 @@ export const signUpWithEmail = async (email: string, password: string) => {
   try {
     const result = await createUserWithEmailAndPassword(auth, email, password);
     const token = await result.user.getIdToken();
-    document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax`;
+    document.cookie = `firebaseIdToken=${token}; path=/; SameSite=Lax; Secure`;
     return result.user;
   } catch (error) {
     console.error("Error signing up with email:", error);
@@ -55,7 +55,7 @@ export const signUpWithEmail = async (email: string, password: string) => {
 export const logoutUser = async () => {
   try {
     await signOut(auth);
-    document.cookie = "firebaseIdToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax";
+    document.cookie = "firebaseIdToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax; Secure";
   } catch (error) {
     console.error("Error signing out:", error);
     throw error;


### PR DESCRIPTION
This commit reverts the previous change that removed the `Secure` flag from the authentication cookie.

The removal of the flag was correlated with a 502 server crash. This revert is intended to bring the server back to a stable, running state.

Once server stability is confirmed, the original issue of dashboard access can be re-investigated with a different approach.