### PR TITLE
Fix: Set middleware runtime to Node.js to prevent build failure

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 // src/middleware.ts
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';


### PR DESCRIPTION
This commit fixes a critical build failure caused by the incompatibility of the `firebase-admin` package with the default Next.js Edge Runtime.

The middleware was attempting to import `firebase-admin` for session verification, which is not supported in the Edge environment.

The fix is to explicitly set the middleware runtime to 'nodejs' by adding `export const runtime = 'nodejs';` to the top of `src/middleware.ts`.

This change allows the server to build and deploy successfully while keeping the robust server-side authentication architecture in place.