### PR TITLE
Fix: Simplify middleware to be Edge-compatible

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,37 +1,22 @@
-export const runtime = 'nodejs';
-
-// src/middleware.ts
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { authAdmin } from '@/lib/firebase-admin';
 
-async function verifySessionCookie(token: string) {
-  try {
-    await authAdmin.verifyIdToken(token);
-    return true;
-  } catch (error) {
-    return false;
-  }
-}
-
-export async function middleware(request: NextRequest) {
-  const sessionToken = request.cookies.get('__session')?.value;
+export function middleware(request: NextRequest) {
+  const sessionCookie = request.cookies.get('__session');
   const { pathname } = request.nextUrl;
 
   const protectedRoutes = ['/dashboard', '/portfolio', '/trades', '/analytics'];
   const isProtectedRoute = protectedRoutes.some((route) => pathname.startsWith(route));
 
-  const isTokenValid = sessionToken ? await verifySessionCookie(sessionToken) : false;
-
-  if (isProtectedRoute) {
-    if (!isTokenValid) {
-      const loginUrl = new URL('/login', request.url);
-      loginUrl.searchParams.set('redirect_to', pathname);
-      return NextResponse.redirect(loginUrl);
-    }
+  // If trying to access a protected route without a session cookie, redirect to login
+  if (isProtectedRoute && !sessionCookie) {
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('redirect_to', pathname);
+    return NextResponse.redirect(loginUrl);
   }
 
-  if (pathname === '/login' && isTokenValid) {
+  // If logged in (session cookie exists) and trying to access login page, redirect to dashboard
+  if (pathname === '/login' && sessionCookie) {
     const dashboardUrl = new URL('/dashboard', request.url);
     return NextResponse.redirect(dashboardUrl);
   }


### PR DESCRIPTION
This commit refactors the middleware to be compatible with the Next.js Edge runtime, resolving a critical build failure.

Following an excellent architectural suggestion, all server-side session verification logic (`firebase-admin`) has been removed from the middleware. The middleware's responsibility is now simplified to only check for the presence of the `__session` cookie.

This change allows the middleware to run in the default Edge runtime, which is more performant and avoids the build errors encountered previously. This change builds upon the server-side session management architecture implemented previously.