### PR TITLE
Fix: Refactor session API to use native Next.js cookie management

### DIFF
--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,26 +1,27 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { getCookie, setCookie, deleteCookie } from 'cookies-next';
 import { authAdmin } from '@/lib/firebase-admin';
+import { cookies } from 'next/headers';
 
 const SESSION_COOKIE_NAME = '__session';
+const SESSION_DURATION_DAYS = 14;
 
 // GET handler for verifying a session
-export async function GET(request: NextRequest) {
-  const session = getCookie(SESSION_COOKIE_NAME, { req: request });
+export async function GET() {
+  const cookieStore = cookies();
+  const session = cookieStore.get(SESSION_COOKIE_NAME);
 
-  if (!session) {
+  if (!session?.value) {
     return NextResponse.json({ isAuthenticated: false }, { status: 401 });
   }
 
   try {
-    const decodedToken = await authAdmin.verifyIdToken(session);
+    const decodedToken = await authAdmin.verifyIdToken(session.value);
     return NextResponse.json({ isAuthenticated: true, user: decodedToken }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ isAuthenticated: false }, { status: 401 });
   }
 }
-const SESSION_DURATION_DAYS = 14;
 
 // POST handler for creating a session (login)
 export async function POST(request: NextRequest) {
@@ -33,19 +34,17 @@ export async function POST(request: NextRequest) {
     // Verify the ID token.
     await authAdmin.verifyIdToken(token);
 
-    // Set session cookie
-    const response = NextResponse.json({ status: 'success' });
-    setCookie(SESSION_COOKIE_NAME, token, {
-      req: request,
-      res: response,
+    // Use Next.js's built-in cookie management
+    const cookieStore = cookies();
+    cookieStore.set(SESSION_COOKIE_NAME, token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      maxAge: 60 * 60 * 24 * SESSION_DURATION_DAYS, // 14 days
+      maxAge: 60 * 60 * 24 * SESSION_DURATION_DAYS,
       path: '/',
       sameSite: 'lax',
     });
 
-    return response;
+    return NextResponse.json({ status: 'success' });
   } catch (error) {
     console.error('Error creating session:', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
@@ -53,17 +52,10 @@ export async function POST(request: NextRequest) {
 }
 
 // DELETE handler for destroying a session (logout)
-export async function DELETE(request: NextRequest) {
-  try {
-    const response = NextResponse.json({ status: 'success' });
-    deleteCookie(SESSION_COOKIE_NAME, {
-      req: request,
-      res: response,
-      path: '/',
-    });
-    return response;
-  } catch (error) {
-    console.error('Error deleting session:', error);
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
-  }
+export async function DELETE() {
+  // Use Next.js's built-in cookie management
+  const cookieStore = cookies();
+  cookieStore.delete(SESSION_COOKIE_NAME);
+
+  return NextResponse.json({ status: 'success' });
 }


### PR DESCRIPTION
This commit resolves a persistent session creation issue by refactoring the session API to use the built-in Next.js `cookies()` function from `next/headers`.

The previous implementation using the `cookies-next` library was not reliably setting the session cookie in the deployment environment.

This change removes the dependency on `cookies-next` for the API route and replaces it with the officially recommended, robust, and native Next.js API for managing cookies in App Router Route Handlers. This provides the most reliable method for session management and should definitively resolve the bug preventing users from accessing the dashboard after login.