### PR TITLE
Fix: Add error checking for session API calls

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -47,11 +47,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           toast.success("Successfully logged in with Google!");
           const token = await result.user.getIdToken();
           // Create the server-side session
-          await fetch('/api/auth/session', {
+          const response = await fetch('/api/auth/session', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ token }),
           });
+
+          if (!response.ok) {
+            throw new Error('Failed to create server session after redirect.');
+          }
+
           // Now that the session is created, verify it to get the user state
           await verifySession();
         } else {


### PR DESCRIPTION
This commit fixes a bug where failures in the server-side session creation were not being reported to the user.

The client-side `fetch` calls to `/api/auth/session` have been updated to check if the response is `ok`. If the server returns an error status, the client will now throw an error, which will be caught and displayed as a toast notification.

This change is critical for debugging the persistent login issue. It will either resolve the problem by surfacing a previously hidden error, or it will provide the specific error message needed for the final fix.