### PR TITLE
Fix: Correctly implement Google Sign-In redirect flow

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { motion } from "framer-motion"
 import { Eye, EyeOff, Mail, Lock, Chrome } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { ThemeToggle } from "@/components/theme-toggle"
-import { signInWithGoogle, signInWithEmail, signUpWithEmail } from "@/lib/firebase"
+import { signInWithGoogle, signInWithEmail, signUpWithEmail, handleGoogleRedirect } from "@/lib/firebase"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
@@ -18,8 +18,24 @@ export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true) // Start in loading state to handle redirect
   const router = useRouter()
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const user = await handleGoogleRedirect();
+        if (user) {
+          toast.success("Successfully logged in with Google!");
+          router.push("/dashboard");
+        }
+      } catch (error: any) {
+        toast.error(error.message || "Google sign-in failed");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -42,17 +58,15 @@ export default function LoginPage() {
   }
 
   const handleGoogleSignIn = async () => {
-    setLoading(true)
+    setLoading(true);
     try {
-      await signInWithGoogle()
-      toast.success("Successfully logged in with Google!")
-      router.push("/dashboard")
+      await signInWithGoogle();
+      // The redirect will be handled by the useEffect hook after Google redirects back to this page.
     } catch (error: any) {
-      toast.error(error.message || "Google sign-in failed")
-    } finally {
-      setLoading(false)
+      toast.error(error.message || "Google sign-in failed");
+      setLoading(false);
     }
-  }
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center justify-center p-4">

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -39,47 +39,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     };
 
-    // First, handle the potential redirect from Google Sign-In
-    getRedirectResult(auth)
-      .then(async (result) => {
-        if (result) {
-          // A user has just signed in via redirect.
-          toast.success("Successfully logged in with Google!");
-          const token = await result.user.getIdToken();
-          // Create the server-side session
-          const response = await fetch('/api/auth/session', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ token }),
-          });
+    verifySession();
 
-          if (!response.ok) {
-            throw new Error('Failed to create server session after redirect.');
-          }
-
-          // Now that the session is created, verify it to get the user state
-          await verifySession();
-        } else {
-          // No redirect result, just verify the existing session
-          await verifySession();
-        }
-      })
-      .catch((error) => {
-        console.error("Error getting redirect result:", error);
-        toast.error(error.message || "Google sign-in failed");
-        verifySession(); // Still try to verify session even if redirect fails
-      });
-
-    // Optional: Listen for client-side auth state changes to handle token expiry or sign-outs from other tabs.
+    // Listen for client-side auth state changes to handle sign-outs from other tabs.
     const unsubscribe = onAuthStateChanged(auth, (clientUser) => {
       if (!clientUser && user) {
-        // User signed out on the client, sync the state
-        setUser(null);
+        // User signed out on the client, sync the state by re-verifying
+        // This handles the case where logoutUser() is called.
+        verifySession();
       }
     });
 
     return () => unsubscribe();
-  }, []);
+  }, [user]);
 
   return (
     <AuthContext.Provider value={{ user, loading }}>

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -66,3 +66,23 @@ export const logoutUser = async () => {
   }
   await signOut(auth);
 };
+
+export const handleGoogleRedirect = async () => {
+  const result = await getRedirectResult(auth);
+  if (result?.user) {
+    const token = await result.user.getIdToken();
+
+    const response = await fetch('/api/auth/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to create server session.');
+    }
+
+    return result.user;
+  }
+  return null;
+};


### PR DESCRIPTION
This commit fixes a critical bug in the Google Sign-In process where the user was not being properly authenticated after being redirected back from Google.

The previous implementation did not correctly handle the `getRedirectResult` flow. The client was being redirected to the dashboard before the session could be established.

This fix implements the correct pattern as advised:
1.  A new `handleGoogleRedirect` function has been added to `src/lib/firebase.ts` to process the redirect result and create the server-side session.
2.  A `useEffect` hook has been added to the login page (`src/app/login/page.tsx`). This hook calls `handleGoogleRedirect` upon page load, ensuring that the session is fully established *before* the user is redirected to the dashboard.
3.  The `AuthProvider` has been simplified, with the responsibility for handling the redirect now correctly placed on the login page.

This change finally ensures a reliable and correct authentication flow for Google Sign-In.